### PR TITLE
Add support for 32 bit indexbuffers

### DIFF
--- a/src/app/imgui_remote.h
+++ b/src/app/imgui_remote.h
@@ -187,15 +187,20 @@ namespace ImGui {
 				{
 					if ( strstr( (char *) data, "ImInit" ) )
 					{
+						// The browser lets us know if it can do 32-bit indexbuffers
 						int supports32bitIB = 0;
 						if ( sscanf( (char *) data, "ImInit;IB32=%d", &supports32bitIB ) == 1 )
 						{
-      							Supports32BitIndexBuffers = ( supports32bitIB != 0 );
+							Supports32BitIndexBuffers = ( supports32bitIB != 0 );
 						}
 						ClientActive = true;
 						ForceKeyFrame = true;
-						// Send confirmation
-						SendText( "ImInit", 6 );
+						// Send confirmation with the indexbuffer size we negotiated
+						// (This is for backwards compatibility, where if we don't send this header,
+						// a newer client won't increase the element size)
+						char sz[ 32 ];
+						snprintf( sz, 32, "ImInit;IB32=%d", Supports32BitIndexBuffers ? 1 : 0 );
+						SendText( sz, strlen( sz ) );
 						// Send font texture
 						unsigned char* pixels;
 						int width, height;

--- a/src/client/imgui.js
+++ b/src/client/imgui.js
@@ -229,14 +229,18 @@ function StartImgui( element, serveruri, targetwidth, targetheight, compressed )
             datgui_connectionStatus.setValue( "Disconnected" );
         };
         websocket.onmessage = function( evt ) {
-            if( typeof evt.data == "string" ) {
-                if( evt.data == "ImInit" )
-                {
-                    console.log( "ImInit OK" );
+            if (typeof evt.data == "string") {
+                var arr = evt.data.split(";");
+                if (arr[0] == "ImInit") {
+                    if (arr.indexOf("IB32=1")==-1)
+                    {
+                      support32BitIndices = false;
+                    }
+                    console.log("ImInit OK");
                     clientactive = true;
                 }
                 else
-                    console.log( "Unknown message: " + evt.data ); 
+                    console.log("Unknown message: " + evt.data);
             }
             else {
                 var data;


### PR DESCRIPTION
Apparently there's a browser GL extension for 32 bit indexbuffers, so I added a little on-init negotiation that decides whether that can be used.